### PR TITLE
confusing variable name in `traverse`

### DIFF
--- a/src/muse/protocol.cljc
+++ b/src/muse/protocol.cljc
@@ -209,8 +209,8 @@
     (value [])))
 
 (defn traverse
-  [f muses]
-  (flat-map #(collect (map f %)) muses))
+  [f muse]
+  (flat-map #(collect (map f %)) muse))
 
 (defn next-level
   [ast-node]


### PR DESCRIPTION
Following name convention in this repo, `muses` refers to the collections of `muse` nodes, but `traverse` function expects a single `muse` node with a collection of values inside it. So it's better to fix this name, because we haven't any documentation for now :)